### PR TITLE
case without getGeneralInfo in performance + test

### DIFF
--- a/src/Apm.ts
+++ b/src/Apm.ts
@@ -10,17 +10,19 @@ export default class Apm {
     }
 
     getGeneralInfo(): GeneralInfo {
-        const perf: PerformanceNavigationTiming | undefined =
-            this.performance.getEntriesByType('navigation')[0] as (PerformanceNavigationTiming | undefined);
+        if ('getEntriesByType' in this.performance) {
+            const perf: PerformanceNavigationTiming | undefined =
+                this.performance.getEntriesByType('navigation')[0] as (PerformanceNavigationTiming | undefined);
 
-        return new GeneralInfo(
-            this.navigator.userAgent,
-            this.navigator.connection,
-            perf
-        );
+            return new GeneralInfo(
+                this.navigator.userAgent,
+                this.navigator.connection,
+                perf
+            );
+        }
+        return new GeneralInfo(this.navigator.userAgent, this.navigator.connection)
+
     }
-
-
 }
 
 interface WindowInterface {

--- a/test/general-info/general-info.test.ts
+++ b/test/general-info/general-info.test.ts
@@ -29,3 +29,28 @@ describe('getGeneralInfo', () => {
         expect(info.userAgent).toBe('UA');
     })
 })
+
+describe('getGeneralInfo without getEntriesByType', () => {
+    const performance = {}
+
+    const window = {
+        navigator: {userAgent: 'UA', connection: {type: 'wifi'}} as Navigator,
+        performance: performance as unknown as Performance
+    };
+
+    const apm = new Apm(window);
+
+    const info = apm.getGeneralInfo();
+
+    test('timings', () => {
+        expect(info.timing).toBe(undefined)
+    });
+
+    test('connection', () => {
+        expect(info.connection && info.connection.type).toBe('wifi');
+    });
+
+    test('user agent', () => {
+        expect(info.userAgent).toBe('UA');
+    })
+})


### PR DESCRIPTION
func getEntriesByType missing in old version Safari 